### PR TITLE
add support for "success" output for edit command

### DIFF
--- a/pkg/kubectl/genericclioptions/json_yaml_flags.go
+++ b/pkg/kubectl/genericclioptions/json_yaml_flags.go
@@ -25,6 +25,9 @@ import (
 )
 
 func (f *JSONYamlPrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
 	return []string{"json", "yaml"}
 }
 

--- a/pkg/kubectl/genericclioptions/name_flags.go
+++ b/pkg/kubectl/genericclioptions/name_flags.go
@@ -41,6 +41,9 @@ func (f *NamePrintFlags) Complete(successTemplate string) error {
 }
 
 func (f *NamePrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
 	return []string{"name"}
 }
 


### PR DESCRIPTION
Uses error-handling / printer-matching from the PrintFlags struct
while supporting "successful" printer output.